### PR TITLE
fix: dark mode toggle and broken image paths on GitHub Pages

### DIFF
--- a/portfolio/src/components/layout/Navbar.tsx
+++ b/portfolio/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Theme } from '../../types';
+import { imgUrl } from '../../utils/assets';
 
 interface NavbarProps {
   theme: Theme;
@@ -43,7 +44,7 @@ export function Navbar({ theme, onToggleTheme }: NavbarProps) {
             className="flex items-center gap-2 rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mauve"
           >
             <img
-              src="/images/ZRN-Logo.svg"
+              src={imgUrl('/images/ZRN-Logo.svg')}
               alt="ZRN Logo"
               className="h-8 w-auto"
               onError={(e) => {

--- a/portfolio/src/components/sections/About.tsx
+++ b/portfolio/src/components/sections/About.tsx
@@ -1,4 +1,5 @@
 import { SectionTitle } from '../ui/SectionTitle';
+import { imgUrl } from '../../utils/assets';
 
 export function About() {
   return (
@@ -18,13 +19,13 @@ export function About() {
           <div className="relative">
             <div className="grid grid-cols-2 gap-4">
               <img
-                src="/images/me-1.jpg"
+                src={imgUrl('/images/me-1.jpg')}
                 alt="Mohamed Zarandah"
                 className="w-full rounded-2xl object-cover aspect-[3/4] shadow-xl"
                 loading="lazy"
               />
               <img
-                src="/images/me-2.jpg"
+                src={imgUrl('/images/me-2.jpg')}
                 alt="Mohamed Zarandah"
                 className="w-full rounded-2xl object-cover aspect-[3/4] shadow-xl mt-8"
                 loading="lazy"

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -1,4 +1,5 @@
 import { Button } from '../ui/Button';
+import { imgUrl } from '../../utils/assets';
 
 export function Hero() {
   return (
@@ -11,7 +12,7 @@ export function Hero() {
       <div
         className="absolute right-0 top-0 bottom-0 w-1/2 opacity-[0.07] dark:opacity-[0.04] pointer-events-none"
         style={{
-          backgroundImage: 'url(/images/homepage-bkg.png)',
+          backgroundImage: `url(${imgUrl('/images/homepage-bkg.png')})`,
           backgroundSize: '50rem',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'right center',

--- a/portfolio/src/data/projects.ts
+++ b/portfolio/src/data/projects.ts
@@ -1,4 +1,5 @@
 import type { Project } from '../types';
+import { imgUrl } from '../utils/assets';
 
 export const projects: Project[] = [
   {
@@ -13,7 +14,7 @@ export const projects: Project[] = [
       'Signature Lipstick Collection inspired by vibrant Latin colors. Sultry Eyeshadow Palette with rich earthy tones. Radiance Foundation with lightweight, natural-finish formula.',
     review:
       '"Kavorka\'s products are a true reflection of elegance and quality. I love how they embrace Latin beauty traditions while offering modern choices." — Maria, Makeup Enthusiast',
-    imageUrl: '/images/kavorka-banner.png',
+    imageUrl: imgUrl('/images/kavorka-banner.png'),
     tags: ['Branding', 'UI Design', 'Figma'],
     category: 'design',
   },
@@ -29,7 +30,7 @@ export const projects: Project[] = [
       'Immersive Sound Experience. Sleek and Comfortable ergonomic design. Intuitive Touch Controls. Seamless user experience across all devices.',
     review:
       '"Simply put, these MHZ earbuds have elevated my music experience. Clear sound, comfortable fit — a game-changer for daily use!"',
-    imageUrl: '/images/mhz-banner.png',
+    imageUrl: imgUrl('/images/mhz-banner.png'),
     tags: ['Web Design', 'HTML', 'CSS', 'GSAP'],
     category: 'web',
   },
@@ -45,7 +46,7 @@ export const projects: Project[] = [
       'Strategic diversification into adult beverages. Focus on craft seltzers. Complete contemporary rebranding that speaks to the adult market.',
     review:
       '"Quatro\'s beverage is a taste revolution! A burst of unique flavors that left me craving more." — Emily M., Flavor Explorer',
-    imageUrl: '/images/quatro-banner.png',
+    imageUrl: imgUrl('/images/quatro-banner.png'),
     tags: ['Branding', 'Web Design', 'UI/UX'],
     category: 'design',
   },
@@ -61,7 +62,7 @@ export const projects: Project[] = [
       '3D model and video demonstration support. Virtual business card exchanges. Scheduled one-on-one video meetings. Real-time feedback from industry professionals.',
     review:
       '"I recently had the pleasure of using the innovative digital platform developed for Fanshawe College\'s Industry Night, and it exceeded all my expectations!"',
-    imageUrl: '/images/bootcamp-banner.png',
+    imageUrl: imgUrl('/images/bootcamp-banner.png'),
     tags: ['React', 'UI/UX', 'WebView', 'Fanshawe'],
     category: 'web',
   },
@@ -77,7 +78,7 @@ export const projects: Project[] = [
       'Collaborated directly with the founder. Comprehensive audience research. Consistent color scheme and cohesive design. Fully responsive across all devices.',
     review:
       '"After participating in the Event Simplified website design project, I am thoroughly impressed with the comprehensive learning experience it provided." ',
-    imageUrl: '/images/event-simplified-banner.png',
+    imageUrl: imgUrl('/images/event-simplified-banner.png'),
     tags: ['Web Design', 'HTML', 'CSS/SCSS', 'Responsive'],
     category: 'web',
   },
@@ -93,7 +94,7 @@ export const projects: Project[] = [
       'Intuitive resource navigation. Community support systems. Educational workshops and content. Destigmatizing mental health through design.',
     review:
       '"I stumbled upon Foundation Sixty 6\'s website during a difficult time, and it was a beacon of hope."',
-    imageUrl: '/images/foundation-sixty6-banner.png',
+    imageUrl: imgUrl('/images/foundation-sixty6-banner.png'),
     tags: ['Web Design', 'HTML', 'CSS', 'Accessibility'],
     category: 'web',
   },
@@ -109,7 +110,7 @@ export const projects: Project[] = [
       'Compelling visual narratives on human rights. Bridge connecting diverse communities. Artistic activism through design.',
     review:
       '"I recently came across this series of posters designed to reflect on the profound effects of human rights, and I was deeply moved."',
-    imageUrl: '/images/fundraising-campaign-banner.png',
+    imageUrl: imgUrl('/images/fundraising-campaign-banner.png'),
     tags: ['Poster Design', 'Adobe Illustrator', 'Adobe Photoshop'],
     category: 'design',
   },
@@ -125,7 +126,7 @@ export const projects: Project[] = [
       'Innovative cinematography techniques. Blend of real-world and digital artistry. Collaborative filmmaking process documented.',
     review:
       '"Fragments of Reality is a mesmerizing journey through the complexities of human emotion and perception."',
-    imageUrl: '/images/fragments-banner.png',
+    imageUrl: imgUrl('/images/fragments-banner.png'),
     tags: ['Video Production', 'Adobe Premiere', 'After Effects'],
     category: 'video',
   },
@@ -141,7 +142,7 @@ export const projects: Project[] = [
       'Lumen JS frontend. RESTful Backend API integration. Optimized queries for minimal response times. Clean, clutter-free UX for manga discovery.',
     review:
       '"Discovering the manga API webstore was an absolute game-changer for how I consume manga. Smooth and intuitive!"',
-    imageUrl: '/images/manga-api-banner.png',
+    imageUrl: imgUrl('/images/manga-api-banner.png'),
     tags: ['PHP', 'Lumen JS', 'REST API', 'MySQL'],
     category: 'api',
   },
@@ -157,7 +158,7 @@ export const projects: Project[] = [
       'Intimate storytelling and dynamic cinematography. Natural lighting and close-up techniques. Tribute to small family businesses and community.',
     review:
       '"The video is nothing short of inspiring. From the moment it begins, you\'re drawn into the heartfelt story of resilience and family bonds."',
-    imageUrl: '/images/mothersun-banner.png',
+    imageUrl: imgUrl('/images/mothersun-banner.png'),
     tags: ['Video Production', 'Cinematography', 'Storytelling'],
     category: 'video',
   },
@@ -173,7 +174,7 @@ export const projects: Project[] = [
       'High-quality automotive photography. Deep-dive articles on iconic models. Personal road trip anecdotes. Community hub for car enthusiasts.',
     review:
       '"Discovering this self-built website dedicated to car enthusiasm was an absolute delight. The passion behind every page is evident from the first click."',
-    imageUrl: '/images/csl-banner.png',
+    imageUrl: imgUrl('/images/csl-banner.png'),
     tags: ['HTML', 'CSS', 'JavaScript', 'Responsive'],
     category: 'web',
   },
@@ -189,7 +190,7 @@ export const projects: Project[] = [
       'Optimized API queries for minimal latency. Structured data retrieval for characters, planets, vehicles. Developer-friendly and well-documented.',
     review:
       '"Exploring this Star Wars API file was enthralling. Its clarity, efficiency, and thoughtful design stood out for developers of all skill levels."',
-    imageUrl: '/images/starwars-banner.png',
+    imageUrl: imgUrl('/images/starwars-banner.png'),
     tags: ['JavaScript', 'REST API', 'Fetch API'],
     category: 'api',
   },

--- a/portfolio/src/index.css
+++ b/portfolio/src/index.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Enable class-based dark mode (Tailwind v4 defaults to media query) */
+@variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Cream palette */
   --color-cream: #f5ebe0;

--- a/portfolio/src/utils/assets.ts
+++ b/portfolio/src/utils/assets.ts
@@ -1,0 +1,3 @@
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+export const imgUrl = (path: string) => `${base}${path}`;


### PR DESCRIPTION
## Fixes

### 1. Dark mode toggle had no effect
Tailwind v4 defaults `dark:` to `@media (prefers-color-scheme: dark)` instead of the `.dark` class. Added `@variant dark (&:where(.dark, .dark *))` to `index.css` to switch it to class-based dark mode.

### 2. Images broken on GitHub Pages
Absolute paths like `/images/me-1.jpg` ignore Vite's `base` config and resolve from the domain root. On GitHub Pages (subpath `/Zarandah_Mohamed_Portfolio/`), this returns 404.

Added `src/utils/assets.ts` with `imgUrl()` that prefixes `import.meta.env.BASE_URL`, which Vite sets correctly in both dev and production. Updated Navbar, Hero, About, and all 12 project entries.

## Test plan
- [ ] Dark/light toggle switches colours correctly
- [ ] All project banners load in the Projects section
- [ ] Photos load in the About section
- [ ] Logo and hero background image load correctly
- [ ] Works on both localhost and GitHub Pages URL

https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot

---
_Generated by [Claude Code](https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot)_