### PR TITLE
Fix hero background image and simplify navbar logo

### DIFF
--- a/portfolio/src/components/layout/Navbar.tsx
+++ b/portfolio/src/components/layout/Navbar.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import type { Theme } from '../../types';
-import { imgUrl } from '../../utils/assets';
 
 interface NavbarProps {
   theme: Theme;
@@ -41,18 +40,11 @@ export function Navbar({ theme, onToggleTheme }: NavbarProps) {
           {/* Logo */}
           <a
             href="#hero"
-            className="flex items-center gap-2 rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mauve"
+            className="flex items-center rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mauve"
           >
-            <img
-              src={imgUrl('/images/ZRN-Logo.svg')}
-              alt="ZRN Logo"
-              className="h-8 w-auto dark:invert dark:opacity-90"
-              onError={(e) => {
-                (e.target as HTMLImageElement).style.display = 'none';
-              }}
-            />
-            <span className="font-bold text-lg text-[#333] dark:text-white tracking-tight">
-              ZRN
+            <span className="font-bold text-xl tracking-tight">
+              <span className="text-mauve">Z</span>
+              <span className="text-[#333] dark:text-white">RN</span>
             </span>
           </a>
 

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -1,5 +1,4 @@
 import { Button } from '../ui/Button';
-import { imgUrl } from '../../utils/assets';
 
 export function Hero() {
   return (
@@ -8,16 +7,9 @@ export function Hero() {
       className="relative min-h-screen flex items-center overflow-hidden bg-cream dark:bg-warm-950"
       aria-label="Hero"
     >
-      {/* Decorative background image — right side, subtle */}
-      <div
-        className="absolute right-0 top-0 bottom-0 w-1/2 opacity-[0.07] dark:opacity-[0.04] pointer-events-none"
-        style={{
-          backgroundImage: `url(${imgUrl('/images/homepage-bkg.png')})`,
-          backgroundSize: '50rem',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'right center',
-        }}
-      />
+      {/* Decorative blobs */}
+      <div className="absolute top-0 right-0 w-[600px] h-[600px] rounded-full bg-mauve/5 dark:bg-mauve/8 blur-3xl pointer-events-none -translate-y-1/4 translate-x-1/4" />
+      <div className="absolute bottom-0 left-0 w-[400px] h-[400px] rounded-full bg-mauve/5 dark:bg-mauve/5 blur-3xl pointer-events-none translate-y-1/3 -translate-x-1/3" />
 
       <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-32">
         {/* Available badge */}


### PR DESCRIPTION
## Summary

- **Hero background**: Removed the `homepage-bkg.png` silhouette that was visible and out of place in dark mode. Replaced with subtle CSS radial gradient blobs (mauve-tinted) that add depth without the awkward figure shape.
- **Navbar logo**: Removed the ZRN SVG logo image. Replaced with a clean word mark — mauve `Z` + dark/white `RN` — no image dependency, looks sharp in both light and dark mode.

## Test plan

- [ ] Hero section has no silhouette/image shape in background
- [ ] Subtle gradient blobs visible (very subtle — top-right and bottom-left)
- [ ] Navbar shows `ZRN` word mark, `Z` in mauve
- [ ] Both light and dark mode look correct

https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot

---
_Generated by [Claude Code](https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot)_