### PR TITLE
Add AI Outreach Engine, Notion→Discord Bot, and Noctura Pulse projects

### DIFF
--- a/portfolio/public/images/lemlist-banner.svg
+++ b/portfolio/public/images/lemlist-banner.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e1010"/>
+      <stop offset="100%" stop-color="#2d1a1a"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#885a5a" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#885a5a" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <circle cx="950" cy="150" r="350" fill="#885a5a" opacity="0.07"/>
+  <circle cx="200" cy="600" r="250" fill="#885a5a" opacity="0.05"/>
+  <rect x="0" y="0" width="500" height="675" fill="url(#glow)"/>
+  <!-- Grid lines decorative -->
+  <line x1="0" y1="225" x2="1200" y2="225" stroke="#885a5a" stroke-opacity="0.08" stroke-width="1"/>
+  <line x1="0" y1="450" x2="1200" y2="450" stroke="#885a5a" stroke-opacity="0.08" stroke-width="1"/>
+  <line x1="400" y1="0" x2="400" y2="675" stroke="#885a5a" stroke-opacity="0.08" stroke-width="1"/>
+  <line x1="800" y1="0" x2="800" y2="675" stroke="#885a5a" stroke-opacity="0.08" stroke-width="1"/>
+  <!-- Tag -->
+  <rect x="80" y="200" width="130" height="32" rx="16" fill="#885a5a" opacity="0.25"/>
+  <text x="145" y="222" font-family="system-ui, sans-serif" font-size="13" fill="#c49090" text-anchor="middle" font-weight="600" letter-spacing="2">AUTOMATION</text>
+  <!-- Title -->
+  <text x="80" y="310" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#f5ebe0">AI Outreach</text>
+  <text x="80" y="385" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#885a5a">Engine</text>
+  <!-- Subtitle -->
+  <text x="80" y="440" font-family="system-ui, sans-serif" font-size="20" fill="#c49090" opacity="0.8">Node.js · Ollama · LLaMA 3.1 · Gmail · Google Sheets</text>
+  <!-- Dots -->
+  <circle cx="80" cy="520" r="5" fill="#885a5a" opacity="0.6"/>
+  <circle cx="100" cy="520" r="5" fill="#885a5a" opacity="0.4"/>
+  <circle cx="120" cy="520" r="5" fill="#885a5a" opacity="0.2"/>
+</svg>

--- a/portfolio/public/images/noctura-banner.svg
+++ b/portfolio/public/images/noctura-banner.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1020"/>
+      <stop offset="100%" stop-color="#1e1010"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#885a5a" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#885a5a" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <circle cx="1000" cy="100" r="400" fill="#885a5a" opacity="0.07"/>
+  <circle cx="100" cy="550" r="300" fill="#885a5a" opacity="0.05"/>
+  <ellipse cx="600" cy="337" rx="500" ry="200" fill="url(#glow)"/>
+  <!-- Grid lines decorative -->
+  <line x1="0" y1="225" x2="1200" y2="225" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="0" y1="450" x2="1200" y2="450" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="400" y1="0" x2="400" y2="675" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="800" y1="0" x2="800" y2="675" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <!-- Tag -->
+  <rect x="80" y="200" width="150" height="32" rx="16" fill="#885a5a" opacity="0.25"/>
+  <text x="155" y="222" font-family="system-ui, sans-serif" font-size="13" fill="#c49090" text-anchor="middle" font-weight="600" letter-spacing="2">AI · INSTAGRAM</text>
+  <!-- Title -->
+  <text x="80" y="310" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#f5ebe0">Noctura</text>
+  <text x="80" y="385" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#885a5a">Pulse</text>
+  <!-- Subtitle -->
+  <text x="80" y="440" font-family="system-ui, sans-serif" font-size="20" fill="#c49090" opacity="0.8">Python · Claude API · instagrapi · SQLite · Notion</text>
+  <!-- Dots -->
+  <circle cx="80" cy="520" r="5" fill="#885a5a" opacity="0.6"/>
+  <circle cx="100" cy="520" r="5" fill="#885a5a" opacity="0.4"/>
+  <circle cx="120" cy="520" r="5" fill="#885a5a" opacity="0.2"/>
+</svg>

--- a/portfolio/public/images/notion-discord-banner.svg
+++ b/portfolio/public/images/notion-discord-banner.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e1010"/>
+      <stop offset="100%" stop-color="#2d1a1a"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="1" y1="0" x2="0" y2="0">
+      <stop offset="0%" stop-color="#885a5a" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#885a5a" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <circle cx="250" cy="180" r="300" fill="#885a5a" opacity="0.06"/>
+  <circle cx="1050" cy="500" r="280" fill="#885a5a" opacity="0.05"/>
+  <rect x="700" y="0" width="500" height="675" fill="url(#glow)"/>
+  <!-- Grid lines decorative -->
+  <line x1="0" y1="225" x2="1200" y2="225" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="0" y1="450" x2="1200" y2="450" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="400" y1="0" x2="400" y2="675" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <line x1="800" y1="0" x2="800" y2="675" stroke="#885a5a" stroke-opacity="0.07" stroke-width="1"/>
+  <!-- Tag -->
+  <rect x="80" y="200" width="100" height="32" rx="16" fill="#885a5a" opacity="0.25"/>
+  <text x="130" y="222" font-family="system-ui, sans-serif" font-size="13" fill="#c49090" text-anchor="middle" font-weight="600" letter-spacing="2">BOT</text>
+  <!-- Title -->
+  <text x="80" y="310" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#f5ebe0">Notion →</text>
+  <text x="80" y="385" font-family="system-ui, sans-serif" font-size="62" font-weight="800" fill="#885a5a">Discord Bot</text>
+  <!-- Subtitle -->
+  <text x="80" y="440" font-family="system-ui, sans-serif" font-size="20" fill="#c49090" opacity="0.8">Node.js · Discord.js · Notion API · Express · Railway</text>
+  <!-- Dots -->
+  <circle cx="80" cy="520" r="5" fill="#885a5a" opacity="0.6"/>
+  <circle cx="100" cy="520" r="5" fill="#885a5a" opacity="0.4"/>
+  <circle cx="120" cy="520" r="5" fill="#885a5a" opacity="0.2"/>
+</svg>

--- a/portfolio/src/data/projects.ts
+++ b/portfolio/src/data/projects.ts
@@ -204,4 +204,55 @@ export const projects: Project[] = [
     tags: ['JavaScript', 'REST API', 'Fetch API'],
     category: 'api',
   },
+  {
+    id: 13,
+    title: 'AI Outreach Engine',
+    slug: 'lemlist',
+    description:
+      'A fully automated B2B cold outreach pipeline — discovers jobs, enriches contacts, generates personalised emails with a local AI model, and sends via Gmail. Zero API cost.',
+    about:
+      'A self-hosted B2B outreach engine that runs 24/7 on Render. It searches Greenhouse, Lever, Ashby, Wellfound, and LinkedIn every 6 hours across 4 role lanes, scores leads (0–100), generates personalised cold emails + LinkedIn DMs using a local LLaMA 3.1 model via Ollama, builds a lane-specific PDF resume per job, and saves Gmail drafts for review — all at zero ongoing AI cost.',
+    highlights:
+      'Job discovery across 5 boards with 20 targeted queries every 6 hours. Rules-based lead scoring (0–100) with 3 priority tiers. AI email and LinkedIn DM generation using local LLaMA 3.1 via Ollama at zero API cost. Tailored PDF resume built per job attached to every Gmail draft. A/B prompt testing with SQLite tracking and auto-promotion of winning variant. Day 3 and Day 7 follow-up sequences with IMAP reply detection to cancel on response. Google Sheets integration — approve a row and the engine picks it up automatically. Live Express.js dashboard deployed 24/7 on Render.',
+    review:
+      '"Full pipeline in one command. The A/B prompt testing and lead scoring alone saved hours of manual triage every week."',
+    imageUrl: imgUrl('/images/lemlist-banner.svg'),
+    tags: ['Node.js', 'Ollama', 'LLaMA 3.1', 'Gmail IMAP', 'Google Sheets', 'SQLite', 'PDFKit', 'Render'],
+    liveUrl: 'https://lemlist-partner-engine.onrender.com',
+    githubUrl: 'https://github.com/mohamedzrn/lemlist-partner-engine',
+    category: 'api',
+  },
+  {
+    id: 14,
+    title: 'Notion → Discord Bot',
+    slug: 'notion-discord',
+    description:
+      'A real-time automation bot that bridges Notion and Discord — DMing team members on task creation, reassignment, updates, and overdue alerts so nothing falls through the cracks.',
+    about:
+      'A full-stack bot deployed on Railway that keeps async teams accountable without micromanaging. It runs a dual notification system — 10-second polling loop plus real-time Notion webhooks (HMAC-SHA256 verified) — and automatically DMs team members for every meaningful task event. Auto-discovers Notion databases so no manual config is needed.',
+    highlights:
+      'Dual notification system: 10-second polling plus real-time Notion webhooks with HMAC-SHA256 verification. 5 automated DM types: new task, reassignment, due date change, status change, overdue alerts. Daily digest every morning with all open assigned tasks. Hourly overdue scanner with daily deduplication to prevent spam. Auto-discovery of Notion databases with graceful catch-up for newly connected ones. 7 slash commands: /mytasks, /teamtasks, /recentupdates, /status, /linknotion, /remind, /forceremind. Notion to Discord user mapping with persistent JSON storage.',
+    review:
+      '"Eliminated the need for manual check-ins entirely. The /teamtasks command alone changed how we run standups."',
+    imageUrl: imgUrl('/images/notion-discord-banner.svg'),
+    tags: ['Node.js', 'Discord.js v14', 'Notion API', 'Express.js', 'Winston', 'Railway'],
+    githubUrl: 'https://github.com/mohamedzrn/notion-discord-bot',
+    category: 'api',
+  },
+  {
+    id: 15,
+    title: 'Noctura Pulse',
+    slug: 'noctura',
+    description:
+      'An AI-powered Instagram trend bot that turns creator behaviour into content intelligence — silently. Creators forward reels and posts; the bot profiles, analyses, and surfaces trend signals.',
+    about:
+      'Noctura Pulse is a stealth Instagram DM bot built for a creator management agency. Creators forward reels, carousels, stories, and clips — the bot analyses each piece with Claude Vision AI and syncs intelligence to per-creator Notion databases automatically. It builds a rolling behavioral content profile per creator, tracking niche drift, audio trends, hook strength, and shareability over time.',
+    highlights:
+      'Adaptive DM polling (45s to 1hr backoff) waking within 30s on activity. Supports 5 content types: Reels, Carousels, Static posts, Stories, and xma_clip format. Claude Vision AI generates visual summaries from thumbnails. 9 signals extracted per submission: niche, trend signals, content style, audio score, hook strength, shareability, engagement pattern, keywords, and actionable content recommendation. Per-creator Notion database routing with auto-set thumbnail gallery covers. Story media captured before 24-hour expiry. Audio bank and keyword bank ranked by cross-creator frequency and reach. Human-paced reply delays (12–50s randomised) with residential proxy for account safety. Live web dashboard with 5 views and 4 API endpoints.',
+    review:
+      '"Replaced our entire manual content research process. The audio bank alone surfaces trends before they peak."',
+    imageUrl: imgUrl('/images/noctura-banner.svg'),
+    tags: ['Python', 'Claude API', 'instagrapi', 'SQLite', 'Notion API', 'Flask', 'Residential Proxy'],
+    category: 'api',
+  },
 ];


### PR DESCRIPTION
## Summary

Adds three new projects to the portfolio, all in the `api` category:

- **AI Outreach Engine** — Node.js B2B cold outreach pipeline with Ollama/LLaMA 3.1, Gmail IMAP, Google Sheets integration, A/B prompt testing, PDF resume generation, and 24/7 Render deployment. Live: https://lemlist-partner-engine.onrender.com | GitHub: mohamedzrn/lemlist-partner-engine
- **Notion → Discord Bot** — Real-time task notification bot with dual sync (10s polling + HMAC-verified webhooks), 7 slash commands, daily digest, overdue scanner, and per-user Notion mapping. Deployed on Railway. GitHub: mohamedzrn/notion-discord-bot
- **Noctura Pulse** — Python/Claude API Instagram DM bot for creator management. Adaptive polling, Claude Vision analysis of 5 content types, 9 extracted signals per submission, per-creator Notion database routing, audio/keyword banks, and stealth account safety measures. GitHub: private

Includes SVG banner images for all three projects styled to match the portfolio's cream/mauve palette.

## Test plan

- [ ] Three new cards visible in Projects section under the `API / Backend` filter
- [ ] Clicking each card opens the detail modal with full highlights
- [ ] AI Outreach Engine shows Live Demo + GitHub links
- [ ] Notion→Discord Bot shows GitHub link only
- [ ] Banner images render correctly on cards and in modal headers
- [ ] All 15 projects still show under `All` filter

https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot

---
_Generated by [Claude Code](https://claude.ai/code/session_01B92rZHkHczoJbbazxdKnot)_